### PR TITLE
changed function call tf.nn.deconv2d to tf.nn.conv2d_transpose for TensorFlow 0.7.0

### DIFF
--- a/ops.py
+++ b/ops.py
@@ -76,7 +76,7 @@ def deconv2d(input_, output_shape,
         # filter : [height, width, output_channels, in_channels]
         w = tf.get_variable('w', [k_h, k_h, output_shape[-1], input_.get_shape()[-1]],
                             initializer=tf.random_normal_initializer(stddev=stddev))
-        deconv = tf.nn.deconv2d(input_, w, output_shape=output_shape,
+        deconv = tf.nn.conv2d_transpose(input_, w, output_shape=output_shape,
                                 strides=[1, d_h, d_w, 1])
 
         biases = tf.get_variable('biases', [output_shape[-1]], initializer=tf.constant_initializer(0.0))

--- a/ops.py
+++ b/ops.py
@@ -76,7 +76,14 @@ def deconv2d(input_, output_shape,
         # filter : [height, width, output_channels, in_channels]
         w = tf.get_variable('w', [k_h, k_h, output_shape[-1], input_.get_shape()[-1]],
                             initializer=tf.random_normal_initializer(stddev=stddev))
-        deconv = tf.nn.conv2d_transpose(input_, w, output_shape=output_shape,
+        
+        try:
+            deconv = tf.nn.conv2d_transpose(input_, w, output_shape=output_shape,
+                                strides=[1, d_h, d_w, 1])
+
+        # Support for verisons of TensorFlow before 0.7.0
+        except AttributeError:
+            deconv = tf.nn.deconv2d(input_, w, output_shape=output_shape,
                                 strides=[1, d_h, d_w, 1])
 
         biases = tf.get_variable('biases', [output_shape[-1]], initializer=tf.constant_initializer(0.0))


### PR DESCRIPTION
I have changed function call `tf.nn.deconv2d` in ops.py to `tf.nn.conv2d_transpose` to reflect the name change in TensorFlow 0.7.0.