### PR TITLE
make image output size a parameter

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ flags.DEFINE_float("beta1", 0.5, "Momentum term of adam [0.5]")
 flags.DEFINE_integer("train_size", np.inf, "The size of train images [np.inf]")
 flags.DEFINE_integer("batch_size", 64, "The size of batch images [64]")
 flags.DEFINE_integer("image_size", 108, "The size of image to use (will be center cropped) [108]")
+flags.DEFINE_integer("output_size", 64, "The size of the output images to produce [64]")
 flags.DEFINE_string("dataset", "celebA", "The name of dataset [celebA, mnist, lsun]")
 flags.DEFINE_string("checkpoint_dir", "checkpoint", "Directory name to save the checkpoints [checkpoint]")
 flags.DEFINE_string("sample_dir", "samples", "Directory name to save the image samples [samples]")
@@ -32,10 +33,10 @@ def main(_):
 
     with tf.Session() as sess:
         if FLAGS.dataset == 'mnist':
-            dcgan = DCGAN(sess, image_size=FLAGS.image_size, batch_size=FLAGS.batch_size, y_dim=10, image_shape=[28, 28, 1], c_dim=1,
+            dcgan = DCGAN(sess, image_size=FLAGS.image_size, batch_size=FLAGS.batch_size, y_dim=10, output_size=28, c_dim=1,
                     dataset_name=FLAGS.dataset, is_crop=FLAGS.is_crop, checkpoint_dir=FLAGS.checkpoint_dir)
         else:
-            dcgan = DCGAN(sess, image_size=FLAGS.image_size, batch_size=FLAGS.batch_size,
+            dcgan = DCGAN(sess, image_size=FLAGS.image_size, batch_size=FLAGS.batch_size, output_size=FLAGS.output_size,
                     dataset_name=FLAGS.dataset, is_crop=FLAGS.is_crop, checkpoint_dir=FLAGS.checkpoint_dir)
 
         if FLAGS.is_train:

--- a/utils.py
+++ b/utils.py
@@ -14,8 +14,8 @@ pp = pprint.PrettyPrinter()
 
 get_stddev = lambda x, k_h, k_w: 1/math.sqrt(k_w*k_h*x.get_shape()[-1])
 
-def get_image(image_path, image_size, is_crop=True):
-    return transform(imread(image_path), image_size, is_crop)
+def get_image(image_path, image_size, is_crop=True, resize_w=64):
+    return transform(imread(image_path), image_size, is_crop, resize_w)
 
 def save_images(images, size, image_path):
     return imsave(inverse_transform(images), size, image_path)
@@ -48,10 +48,10 @@ def center_crop(x, crop_h, crop_w=None, resize_w=64):
     return scipy.misc.imresize(x[j:j+crop_h, i:i+crop_w],
                                [resize_w, resize_w])
 
-def transform(image, npx=64, is_crop=True):
+def transform(image, npx=64, is_crop=True, resize_w=64):
     # npx : # of pixels width/height of image
     if is_crop:
-        cropped_image = center_crop(image, npx)
+        cropped_image = center_crop(image, npx, resize_w=resize_w)
     else:
         cropped_image = image
     return np.array(cropped_image)/127.5 - 1.


### PR DESCRIPTION
this makes the output size of the images to produce a parameter.

1) `image_shape` is replaced by `output_size` which specifies the target size of the output images, and is a flag which can be set in `main`.

2) to avoid conflicts between checkpoints made with different `output_size`, it has been appended to the checkpoint names.

this image is the first sample (after 100 batches) of running `python main.py --dataset celebA --is_train True --is_crop True --output_size 96`. i haven't done a full run-through to assess the quality but it appears to be working smoothly.

![train_0_99](https://cloud.githubusercontent.com/assets/1335251/17627206/b288f120-60b0-11e6-9d25-21c2d683e9b5.png)

the only limitation is that `output_size` must be a multiple of 16. 