### PR TITLE
Improved documentation of c_dim

### DIFF
--- a/model.py
+++ b/model.py
@@ -28,6 +28,9 @@ class DCGAN(object):
             gfc_dim: (optional) Dimension of gen untis for for fully connected layer. [1024]
             dfc_dim: (optional) Dimension of discrim units for fully connected layer. [1024]
             c_dim: (optional) Dimension of image color. [3]
+            Note that changing c_dim from its default value may require changing the
+            parameters of scipy.misc.imread() in the function imread() in utils.py and
+            reshaping batch_images in the train() function in model.py, among other things.
         """
         self.sess = sess
         self.is_crop = is_crop


### PR DESCRIPTION
Changing c_dim breaks imread() since scipy.misc.imread generally returns images with 3 channels. It also requires reshaping batch_images during training. This bit of documentation improves clarity and solves issues like #26.

What do you think? If you would like, I could explicitly add support for grayscale images, which is the most common reason as to why c_dim would be modified.