### PR TITLE
Bug in deconv2d

### DIFF
--- a/ops.py
+++ b/ops.py
@@ -86,7 +86,7 @@ def deconv2d(input_, output_shape,
              name="deconv2d", with_w=False):
     with tf.variable_scope(name):
         # filter : [height, width, output_channels, in_channels]
-        w = tf.get_variable('w', [k_h, k_h, output_shape[-1], input_.get_shape()[-1]],
+        w = tf.get_variable('w', [k_h, k_w, output_shape[-1], input_.get_shape()[-1]],
                             initializer=tf.random_normal_initializer(stddev=stddev))
         
         try:


### PR DESCRIPTION
Taking in width and height of kernels instead of only heights