### PR TITLE
should be change in batch normalization

### DIFF
--- a/ops.py
+++ b/ops.py
@@ -32,6 +32,7 @@ class batch_norm(object):
                                             updates_collections=None,
                                             epsilon=self.epsilon,
                                             scale=True,
+                                            is_training=train,
                                             scope=self.name)
 
 


### PR DESCRIPTION
Dear carpedem, 

There is a missing 'is_training' option in  tf.contrib.layers.batch_norm function. 