### PR TITLE
Replace deprecated TensorFlow functions

### DIFF
--- a/model.py
+++ b/model.py
@@ -86,7 +86,7 @@ class DCGAN(object):
 
     self.z = tf.placeholder(
       tf.float32, [None, self.z_dim], name='z')
-    self.z_sum = histogram_summary("z", self.z)
+    self.z_sum = tf.summary.histogram("z", self.z)
 
     if self.y_dim:
       self.G = self.generator(self.z, self.y)
@@ -103,9 +103,9 @@ class DCGAN(object):
       self.sampler = self.sampler(self.z)
       self.D_, self.D_logits_ = self.discriminator(self.G, reuse=True)
 
-    self.d_sum = histogram_summary("d", self.D)
-    self.d__sum = histogram_summary("d_", self.D_)
-    self.G_sum = image_summary("G", self.G)
+    self.d_sum = tf.summary.histogram("d", self.D)
+    self.d__sum = tf.summary.histogram("d_", self.D_)
+    self.G_sum = tf.summary.image("G", self.G)
 
     self.d_loss_real = tf.reduce_mean(
       tf.nn.sigmoid_cross_entropy_with_logits(
@@ -117,13 +117,13 @@ class DCGAN(object):
       tf.nn.sigmoid_cross_entropy_with_logits(
         logits=self.D_logits_, targets=tf.ones_like(self.D_)))
 
-    self.d_loss_real_sum = scalar_summary("d_loss_real", self.d_loss_real)
-    self.d_loss_fake_sum = scalar_summary("d_loss_fake", self.d_loss_fake)
+    self.d_loss_real_sum = tf.summary.scalar("d_loss_real", self.d_loss_real)
+    self.d_loss_fake_sum = tf.summary.scalar("d_loss_fake", self.d_loss_fake)
                           
     self.d_loss = self.d_loss_real + self.d_loss_fake
 
-    self.g_loss_sum = scalar_summary("g_loss", self.g_loss)
-    self.d_loss_sum = scalar_summary("d_loss", self.d_loss)
+    self.g_loss_sum = tf.summary.scalar("g_loss", self.g_loss)
+    self.d_loss_sum = tf.summary.scalar("d_loss", self.d_loss)
 
     t_vars = tf.trainable_variables()
 
@@ -149,11 +149,11 @@ class DCGAN(object):
     except:
       tf.initialize_all_variables().run()
 
-    self.g_sum = merge_summary([self.z_sum, self.d__sum,
+    self.g_sum = tf.summary.merge([self.z_sum, self.d__sum,
       self.G_sum, self.d_loss_fake_sum, self.g_loss_sum])
-    self.d_sum = merge_summary(
+    self.d_sum = tf.summary.merge(
         [self.z_sum, self.d_sum, self.d_loss_real_sum, self.d_loss_sum])
-    self.writer = SummaryWriter("./logs", self.sess.graph)
+    self.writer = tf.summary.FileWriter("./logs", self.sess.graph)
 
     sample_z = np.random.uniform(-1, 1, size=(self.sample_num , self.z_dim))
     
@@ -480,7 +480,7 @@ class DCGAN(object):
     
     y_vec = np.zeros((len(y), self.y_dim), dtype=np.float)
     for i, label in enumerate(y):
-      y_vec[i,y[i]] = 1.0
+      y_vec[i, int(y[i])] = 1.0
     
     return X/255.,y_vec
 

--- a/model.py
+++ b/model.py
@@ -109,13 +109,13 @@ class DCGAN(object):
 
     self.d_loss_real = tf.reduce_mean(
       tf.nn.sigmoid_cross_entropy_with_logits(
-        logits=self.D_logits, labels=tf.ones_like(self.D)))
+        logits=self.D_logits, targets=tf.ones_like(self.D)))
     self.d_loss_fake = tf.reduce_mean(
       tf.nn.sigmoid_cross_entropy_with_logits(
-        logits=self.D_logits_, labels=tf.zeros_like(self.D_)))
+        logits=self.D_logits_, targets=tf.zeros_like(self.D_)))
     self.g_loss = tf.reduce_mean(
       tf.nn.sigmoid_cross_entropy_with_logits(
-        logits=self.D_logits_, labels=tf.ones_like(self.D_)))
+        logits=self.D_logits_, targets=tf.ones_like(self.D_)))
 
     self.d_loss_real_sum = scalar_summary("d_loss_real", self.d_loss_real)
     self.d_loss_fake_sum = scalar_summary("d_loss_fake", self.d_loss_fake)

--- a/utils.py
+++ b/utils.py
@@ -155,7 +155,7 @@ def visualize(sess, dcgan, config, option):
     save_images(samples, [8, 8], './samples/test_%s.png' % strftime("%Y-%m-%d %H:%M:%S", gmtime()))
   elif option == 1:
     values = np.arange(0, 1, 1./config.batch_size)
-    for idx in xrange(100):
+    for idx in range(100):
       print(" [*] %d" % idx)
       z_sample = np.zeros([config.batch_size, dcgan.z_dim])
       for kdx, z in enumerate(z_sample):
@@ -173,7 +173,7 @@ def visualize(sess, dcgan, config, option):
       save_images(samples, [8, 8], './samples/test_arange_%s.png' % (idx))
   elif option == 2:
     values = np.arange(0, 1, 1./config.batch_size)
-    for idx in [random.randint(0, 99) for _ in xrange(100)]:
+    for idx in [random.randint(0, 99) for _ in range(100)]:
       print(" [*] %d" % idx)
       z = np.random.uniform(-0.2, 0.2, size=(dcgan.z_dim))
       z_sample = np.tile(z, (config.batch_size, 1))
@@ -196,7 +196,7 @@ def visualize(sess, dcgan, config, option):
         save_images(samples, [8, 8], './samples/test_%s.png' % strftime("%Y-%m-%d %H:%M:%S", gmtime()))
   elif option == 3:
     values = np.arange(0, 1, 1./config.batch_size)
-    for idx in xrange(100):
+    for idx in range(100):
       print(" [*] %d" % idx)
       z_sample = np.zeros([config.batch_size, dcgan.z_dim])
       for kdx, z in enumerate(z_sample):
@@ -208,7 +208,7 @@ def visualize(sess, dcgan, config, option):
     image_set = []
     values = np.arange(0, 1, 1./config.batch_size)
 
-    for idx in xrange(100):
+    for idx in range(100):
       print(" [*] %d" % idx)
       z_sample = np.zeros([config.batch_size, dcgan.z_dim])
       for kdx, z in enumerate(z_sample): z[idx] = values[kdx]


### PR DESCRIPTION
The functions histogram_summary, image_summary, scalar_summary, merge_summary and SummaryWriter are deprecated. The change replaces them with tf.summary.histogram, tf.summary.image, tf.summary.scalar, tf.summary.merge and tf.summary.FileWriter. Also, the argument name "labels" is replaced with "targets" in sigmoid_cross_entropy_with_logits and y[i] is explicitely cast to integer to address all warnings.