### PR TITLE
Solves indexing error in Python 2.7

### DIFF
--- a/model.py
+++ b/model.py
@@ -473,7 +473,7 @@ class DCGAN(object):
     teY = np.asarray(teY)
     
     X = np.concatenate((trX, teX), axis=0)
-    y = np.concatenate((trY, teY), axis=0)
+    y = np.concatenate((trY, teY), axis=0).astype(np.int)
     
     seed = 547
     np.random.seed(seed)


### PR DESCRIPTION
Currently python complains when indexing because y[i] is a float not an int.