### PR TITLE
sigmoid_cross_entropy_with_logits function was returning None

### DIFF
--- a/model.py
+++ b/model.py
@@ -116,9 +116,9 @@ class DCGAN(object):
 
     def sigmoid_cross_entropy_with_logits(x, y):
       try:
-        tf.nn.sigmoid_cross_entropy_with_logits(logits=x, labels=y)
+        return tf.nn.sigmoid_cross_entropy_with_logits(logits=x, labels=y)
       except:
-        tf.nn.sigmoid_cross_entropy_with_logits(logits=x, targets=y)
+        return tf.nn.sigmoid_cross_entropy_with_logits(logits=x, targets=y)
 
     self.d_loss_real = tf.reduce_mean(
       sigmoid_cross_entropy_with_logits(self.D_logits, tf.ones_like(self.D)))


### PR DESCRIPTION
In the sigmoid_cross_entropy_with_logits function definition it was not returning anything. It should return something which can be used by tf.reduce_mean().