### PR TITLE
fixed invalid markdown image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ After 6th epoch:
 
 After 10th epoch:
 
-![result4](assets/test_2016-01-27 15:08:54.png)
+![result4](assets/test_2016-01-27%2015:08:54.png)
 
 ### Asian face dataset
 


### PR DESCRIPTION
The current link 'assets/test_2016-01-27 15:08:54.png' has a space so it's invalid in markdown and cannot show the image.