### PR TITLE
Fix: Issue #135

### DIFF
--- a/model.py
+++ b/model.py
@@ -294,7 +294,9 @@ class DCGAN(object):
                   self.y:sample_labels,
               }
             )
-            save_images(samples, [8, 8],
+            manifold_h = int(np.ceil(np.sqrt(samples.shape[0])))
+            manifold_w = int(np.round(np.sqrt(samples.shape[0])))
+            save_images(samples, [manifold_h, manifold_w],
                   './{}/train_{:02d}_{:04d}.png'.format(config.sample_dir, epoch, idx))
             print("[Sample] d_loss: %.8f, g_loss: %.8f" % (d_loss, g_loss)) 
           else:
@@ -306,7 +308,9 @@ class DCGAN(object):
                     self.inputs: sample_inputs,
                 },
               )
-              save_images(samples, [8, 8],
+              manifold_h = int(np.ceil(np.sqrt(samples.shape[0])))
+              manifold_w = int(np.round(np.sqrt(samples.shape[0])))
+              save_images(samples, [manifold_h, manifold_w],
                     './{}/train_{:02d}_{:04d}.png'.format(config.sample_dir, epoch, idx))
               print("[Sample] d_loss: %.8f, g_loss: %.8f" % (d_loss, g_loss)) 
             except:

--- a/utils.py
+++ b/utils.py
@@ -43,7 +43,8 @@ def merge_images(images, size):
 
 def merge(images, size):
   h, w = images.shape[1], images.shape[2]
-  img = np.zeros((h * size[0], w * size[1], 3))
+  c = images.shape[3]
+  img = np.zeros((h * size[0], w * size[1], c))
   for idx, image in enumerate(images):
     i = idx % size[1]
     j = idx // size[1]

--- a/utils.py
+++ b/utils.py
@@ -162,7 +162,7 @@ def visualize(sess, dcgan, config, option):
   if option == 0:
     z_sample = np.random.uniform(-0.5, 0.5, size=(config.batch_size, dcgan.z_dim))
     samples = sess.run(dcgan.sampler, feed_dict={dcgan.z: z_sample})
-    save_images(samples, [image_frame_dim, image_frame_dim], './samples/test_%s.png' % strftime("%Y-%m-%d %H:%M:%S", gmtime()))
+    save_images(samples, [image_frame_dim, image_frame_dim], './samples/test_%s.png' % strftime("%Y-%m-%d_%H%M%SS", gmtime()))
   elif option == 1:
     values = np.arange(0, 1, 1./config.batch_size)
     for idx in xrange(100):


### PR DESCRIPTION
save_images() function was hardcoded to handle only 8x8 image samples (batch size of 64)
Now it is calculating the best fitting square to the batch size.

in merge() function the number of channels was hardcoded to handle 3 channels. It might be a problem i.e. 
by using RGBA images (4 channels). I fixed it to get the number of channels from the actual generated samples.