### PR TITLE
fix: Issue #135 

### DIFF
--- a/model.py
+++ b/model.py
@@ -294,7 +294,9 @@ class DCGAN(object):
                   self.y:sample_labels,
               }
             )
-            save_images(samples, [8, 8],
+            manifold_h = int(np.ceil(np.sqrt(samples.shape[0])))
+            manifold_w = int(np.floor(np.sqrt(samples.shape[0])))
+            save_images(samples, [manifold_h, manifold_w],
                   './{}/train_{:02d}_{:04d}.png'.format(config.sample_dir, epoch, idx))
             print("[Sample] d_loss: %.8f, g_loss: %.8f" % (d_loss, g_loss)) 
           else:
@@ -306,7 +308,9 @@ class DCGAN(object):
                     self.inputs: sample_inputs,
                 },
               )
-              save_images(samples, [8, 8],
+              manifold_h = int(np.ceil(np.sqrt(samples.shape[0])))
+              manifold_w = int(np.floor(np.sqrt(samples.shape[0])))
+              save_images(samples, [manifold_h, manifold_w],
                     './{}/train_{:02d}_{:04d}.png'.format(config.sample_dir, epoch, idx))
               print("[Sample] d_loss: %.8f, g_loss: %.8f" % (d_loss, g_loss)) 
             except:


### PR DESCRIPTION
fix: save_images() function was called with fixed 8x8 manifold size -> by other than 64 batch size the images were not generated

save_images() function was hardcoded to handle only 8x8 image samples (batch size of 64)
Now it is calculating the best fitting square to the batch size.