### PR TITLE
fix: merge() now can handle images with other than 3 channels

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -43,7 +43,8 @@ def merge_images(images, size):
 
 def merge(images, size):
   h, w = images.shape[1], images.shape[2]
-  img = np.zeros((h * size[0], w * size[1], 3))
+  c = images.shape[3]
+  img = np.zeros((h * size[0], w * size[1], c))
   for idx, image in enumerate(images):
     i = idx % size[1]
     j = idx // size[1]


### PR DESCRIPTION
in merge() function the number of channels was hardcoded to handle 3 channels. It might be a problem i.e.
by using RGBA images (4 channels). I fixed it to get the number of channels from the actual generated samples.