### PR TITLE
fix: imsave() raised error by images with 1 channels

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -43,13 +43,24 @@ def merge_images(images, size):
 
 def merge(images, size):
   h, w = images.shape[1], images.shape[2]
-  c = images.shape[3]
-  img = np.zeros((h * size[0], w * size[1], c))
-  for idx, image in enumerate(images):
-    i = idx % size[1]
-    j = idx // size[1]
-    img[j*h:j*h+h, i*w:i*w+w, :] = image
-  return img
+  if (images.shape[3] in (3,4)):
+    c = images.shape[3]
+    img = np.zeros((h * size[0], w * size[1], c))
+    for idx, image in enumerate(images):
+      i = idx % size[1]
+      j = idx // size[1]
+      img[j * h:j * h + h, i * w:i * w + w, :] = image
+    return img
+  elif images.shape[3]==1:
+    img = np.zeros((h * size[0], w * size[1]))
+    for idx, image in enumerate(images):
+      i = idx % size[1]
+      j = idx // size[1]
+      img[j * h:j * h + h, i * w:i * w + w] = image[:,:,0]
+    return img
+  else:
+    raise ValueError('in merge(images,size) images parameter '
+                     'must have dimensions: HxW or HxWx3 or HxWx4')
 
 def imsave(images, size, path):
   return scipy.misc.imsave(path, merge(images, size))


### PR DESCRIPTION
scipy.misc.imsave can handle only the images with the following dims:
HxW, HxWx3, HxWx4

imsave() function now handles only images with channels 1, 3 or 4