### PR TITLE
Deel with ValueError in utils.imsave when using mnist.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -63,7 +63,8 @@ def merge(images, size):
                      'must have dimensions: HxW or HxWx3 or HxWx4')
 
 def imsave(images, size, path):
-  return scipy.misc.imsave(path, merge(images, size))
+  image = np.squeeze(merge(images, size))
+  return scipy.misc.imsave(path, image)
 
 def center_crop(x, crop_h, crop_w,
                 resize_h=64, resize_w=64):


### PR DESCRIPTION
When using mnist dataset and c_dim equals 1, the shape of value of  merge(images, size) is (224, 224, 1), while the function scipy.misc.imsave just support these three type of shape: MxN or MxNx3 or MxNx4(https://docs.scipy.org/doc/scipy/reference/generated/scipy.misc.imsave.html).
So we need to squeeze it first.