### PR TITLE
fix unrecognized arguments error

### DIFF
--- a/download.py
+++ b/download.py
@@ -21,7 +21,7 @@ from tqdm import tqdm
 from six.moves import urllib
 
 parser = argparse.ArgumentParser(description='Download dataset for DCGAN.')
-parser.add_argument('datasets', metavar='N', type=str, nargs='+', choices=['celebA', 'lsun', 'mnist'],
+parser.add_argument('--datasets', metavar='N', type=str, nargs='+', choices=['celebA', 'lsun', 'mnist'],
            help='name of dataset to download [celebA, lsun, mnist]')
 
 def download(url, dirpath):


### PR DESCRIPTION
On my macOS 10.12.4, the command [python download.py --datasets "mnist"] causes an unrecognized arguments error. This fixed the problem on my machine and seems to correspond to the argparse documentation.