### PR TITLE
Bug Fix for Checking Grayscale Image

### DIFF
--- a/model.py
+++ b/model.py
@@ -75,7 +75,11 @@ class DCGAN(object):
       self.c_dim = self.data_X[0].shape[-1]
     else:
       self.data = glob(os.path.join("./data", self.dataset_name, self.input_fname_pattern))
-      self.c_dim = imread(self.data[0]).shape[-1]
+      imreadImg = imread(self.data[0]);
+      if len(imreadImg.shape) >= 3: #check if image is a non-grayscale image by checking channel number
+        self.c_dim = imread(self.data[0]).shape[-1]
+      else:
+        self.c_dim = 1
 
     self.grayscale = (self.c_dim == 1)
 


### PR DESCRIPTION
I have attempted to use the program with grayscale images. c_dim will become n for a n x n image (e.g. c_dim = 96 for a 96 x 96 image). By modifying as such, grayscale image could be successfully detected and c_dim will be appropriately assigned with 1.