### PR TITLE
fix generation of sample image non square number of images

### DIFF
--- a/model.py
+++ b/model.py
@@ -298,9 +298,7 @@ class DCGAN(object):
                   self.y:sample_labels,
               }
             )
-            manifold_h = int(np.ceil(np.sqrt(samples.shape[0])))
-            manifold_w = int(np.floor(np.sqrt(samples.shape[0])))
-            save_images(samples, [manifold_h, manifold_w],
+            save_images(samples, image_manifold_size(samples.shape[0]),
                   './{}/train_{:02d}_{:04d}.png'.format(config.sample_dir, epoch, idx))
             print("[Sample] d_loss: %.8f, g_loss: %.8f" % (d_loss, g_loss)) 
           else:
@@ -312,9 +310,7 @@ class DCGAN(object):
                     self.inputs: sample_inputs,
                 },
               )
-              manifold_h = int(np.ceil(np.sqrt(samples.shape[0])))
-              manifold_w = int(np.floor(np.sqrt(samples.shape[0])))
-              save_images(samples, [manifold_h, manifold_w],
+              save_images(samples, image_manifold_size(samples.shape[0]),
                     './{}/train_{:02d}_{:04d}.png'.format(config.sample_dir, epoch, idx))
               print("[Sample] d_loss: %.8f, g_loss: %.8f" % (d_loss, g_loss)) 
             except:

--- a/utils.py
+++ b/utils.py
@@ -241,3 +241,10 @@ def visualize(sess, dcgan, config, option):
     new_image_set = [merge(np.array([images[idx] for images in image_set]), [10, 10]) \
         for idx in range(64) + range(63, -1, -1)]
     make_gif(new_image_set, './samples/test_gif_merged.gif', duration=8)
+
+
+def image_manifold_size(num_images):
+  manifold_w = int(np.floor(np.sqrt(num_images)))
+  manifold_h = int(np.ceil(num_images))
+  assert manifold_w * manifold_h == num_images
+  return manifold_w, manifold_h


### PR DESCRIPTION
settings batch_size to non square numbers can break the generation of sample images, because 
e.g. 
`w=floor(sqrt(32))=5, h=ceil(sqrt(32))=6` but `5*6 = 30 < 32`, so the image generator tries to write beyond the end of the image array. This PR fixes this by calculating the second dimension as `w=ceil(sqrt(size)/h)`