### PR TITLE
del redundant code

### DIFF
--- a/model.py
+++ b/model.py
@@ -495,8 +495,6 @@ class DCGAN(object):
       
   def save(self, checkpoint_dir, step):
     model_name = "DCGAN.model"
-    checkpoint_dir = os.path.join(checkpoint_dir, self.model_dir)
-
     if not os.path.exists(checkpoint_dir):
       os.makedirs(checkpoint_dir)
 


### PR DESCRIPTION
del redundant code  ‘  checkpoint_dir = os.path.join(checkpoint_dir, self.model_dir)
 ’