### PR TITLE
Distributed noise consistency Fixes #206

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -179,7 +179,8 @@ def visualize(sess, dcgan, config, option):
     values = np.arange(0, 1, 1./config.batch_size)
     for idx in xrange(100):
       print(" [*] %d" % idx)
-      z_sample = np.zeros([config.batch_size, dcgan.z_dim])
+      # z_sample = np.zeros([config.batch_size, dcgan.z_dim])
+      z_sample = np.random.uniform(-1, 1, size=[config.batch_size, dcgan.z_dim])
       for kdx, z in enumerate(z_sample):
         z[idx] = values[kdx]
 


### PR DESCRIPTION
Fix the bug that error generated images in this test script by keep distributed noise consistency between train and test process.
```
python main.py  --input_height 48 --output_height 48 --dataset [my_dataset_name] --sample_dir [test_dataset_name]
```