### PR TITLE
load web assets via https

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -34,8 +34,7 @@
 
     <!-- Custom Fonts -->
     <link href="css/font-awesome.min.css" rel="stylesheet" type="text/css">
-    <link href="http://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic" rel="stylesheet" type="text/css">
-    <link href="http://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic|Montserrat:400,700" rel="stylesheet" type="text/css">
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
@@ -225,7 +224,7 @@
                 <h2 lang="en">Algorithm</h2>
             </div>
 
-            <img class="col-md-4 col-md-offset-4 col-xs-10 col-xs-offset-1" src="http://cosmonio.com/Research/Deep-Learning/files/small_1420.png">
+            <img class="col-md-4 col-md-offset-4 col-xs-10 col-xs-offset-1" src="https://cosmonio.com/Research/Deep-Learning/files/small_1420.png">
 
             <div lang="ko" class="col-md-8 col-md-offset-2 col-xs-12 text-left">
                 <p><b>프사 뉴럴</b>의 핵심 모델인 <a href="http://arxiv.org/pdf/1511.06434v2.pdf" target="_blank">DCGAN</a>은 두 개의 인공 신경망으로 구성되어 있으며, 각각</p>
@@ -405,7 +404,7 @@
         })
     </script>
 
-    <script type="text/javascript" src="http://kenwheeler.github.io/slick/slick/slick.js"></script>
+    <script type="text/javascript" src="https://kenwheeler.github.io/slick/slick/slick.js"></script>
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
     <script src="js/vendor/jquery.easing.min.js"></script>
     <script src="js/vendor/pixel.min.js"></script>


### PR DESCRIPTION
Thanks for this awesome work! The web demo is currently down on recent versions of Chrome and FireFox (likely others as well, I only tested these), because recent browser releases block requests for HTTP assets if the loaded page is served via HTTPS. This prevents the demo from loading:

<img width="1126" alt="screen shot 2017-12-25 at 5 16 44 pm" src="https://user-images.githubusercontent.com/4801116/34343290-a523af72-e997-11e7-97ae-bd696efa623a.png">

This simple PR moves the web requests to HTTPS to ensure the assets get loaded and the demo can start. I also combined the Google Fonts requests into a single request :)

<img width="1120" alt="screen shot 2017-12-25 at 5 25 04 pm" src="https://user-images.githubusercontent.com/4801116/34343324-9f312ec2-e998-11e7-9c33-183e1f1371e8.png">
