### PR TITLE
Give informative error msg when no data exists

### DIFF
--- a/model.py
+++ b/model.py
@@ -75,7 +75,10 @@ class DCGAN(object):
       self.data_X, self.data_y = self.load_mnist()
       self.c_dim = self.data_X[0].shape[-1]
     else:
-      self.data = glob(os.path.join(self.data_dir, self.dataset_name, self.input_fname_pattern))
+      data_path = os.path.join(self.data_dir, self.dataset_name, self.input_fname_pattern)
+      self.data = glob(data_path)
+      if len(self.data) == 0:
+        raise Exception("[!] No data found in '" + data_path + "'")
       np.random.shuffle(self.data)
       imreadImg = imread(self.data[0])
       if len(imreadImg.shape) >= 3: #check if image is a non-grayscale image by checking channel number


### PR DESCRIPTION
Print a useful error message when no data exists in the dataset dir.

Example error:
```
Traceback (most recent call last):
  File "main.py", line 103, in <module>
    tf.app.run()
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/platform/app.py", line 126, in run
    _sys.exit(main(argv))
  File "main.py", line 81, in main
    data_dir=FLAGS.data_dir)
  File "/Users/jdenney/workspace/github/forks/DCGAN-tensorflow/model.py", line 81, in __init__
    raise Exception("[!] No data found in '" + data_path + "'")
Exception: [!] No data found in './data/set1/*.jpg'
```

Potentially closes #285, #254, #203, #202,  