### PR TITLE
Raise error if dataset size less than batch_size

### DIFF
--- a/model.py
+++ b/model.py
@@ -85,6 +85,9 @@ class DCGAN(object):
 
     self.grayscale = (self.c_dim == 1)
 
+    if len(self.data) < self.batch_size:
+      raise Exception("[!] Entire dataset size is less than the configured batch_size")
+
     self.build_model()
 
   def build_model(self):


### PR DESCRIPTION
If the entire dataset size is less than the batch_size, then the train model loop gets skipped and results in confusing output (especially for new users), as there is no information about epochs output and grey noise sample images produced.

It issue is caused by batch_idxs getting set to 0 from the // operator in the following logic: https://github.com/carpedm20/DCGAN-tensorflow/blob/master/model.py#L193-L201

In this scenario, the output would now look like this:
```
Traceback (most recent call last):
  File "main.py", line 103, in <module>
    tf.app.run()
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/platform/app.py", line 126, in run
    _sys.exit(main(argv))
  File "main.py", line 81, in main
    data_dir=FLAGS.data_dir)
  File "/Users/jdenney/workspace/github/forks/DCGAN-tensorflow/model.py", line 92, in __init__
    raise Exception("[!] Entire dataset size is less than the configured batch_size")
Exception: [!] Entire dataset size is less than the configured batch_size
```