### PR TITLE
Add informative msg when img size mismatch

### DIFF
--- a/ops.py
+++ b/ops.py
@@ -94,8 +94,13 @@ def linear(input_, output_size, scope=None, stddev=0.02, bias_start=0.0, with_w=
   shape = input_.get_shape().as_list()
 
   with tf.variable_scope(scope or "Linear"):
-    matrix = tf.get_variable("Matrix", [shape[1], output_size], tf.float32,
+    try:
+      matrix = tf.get_variable("Matrix", [shape[1], output_size], tf.float32,
                  tf.random_normal_initializer(stddev=stddev))
+    except ValueError as err:
+        msg = "NOTE: Usually, this is due to an issue with the image dimensions.  Did you correctly set '--crop' or '--input_height' or '--output_height'?"
+        err.args = err.args + (msg,)
+        raise
     bias = tf.get_variable("bias", [output_size],
       initializer=tf.constant_initializer(bias_start))
     if with_w:


### PR DESCRIPTION
Print a useful error message when there is a misconfiguration with image sizes.

Example error:
```
Traceback (most recent call last):
  File "main.py", line 103, in <module>
    tf.app.run()
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/platform/app.py", line 126, in run
    _sys.exit(main(argv))
  File "main.py", line 81, in main
    data_dir=FLAGS.data_dir)
  File "/Users/jdenney/workspace/github/forks/DCGAN-tensorflow/model.py", line 94, in __init__
    self.build_model()
  File "/Users/jdenney/workspace/github/forks/DCGAN-tensorflow/model.py", line 119, in build_model
    self.D_, self.D_logits_ = self.discriminator(self.G, self.y, reuse=True)
  File "/Users/jdenney/workspace/github/forks/DCGAN-tensorflow/model.py", line 333, in discriminator
    h4 = linear(tf.reshape(h3, [self.batch_size, -1]), 1, 'd_h4_lin')
  1 [user]
  File "/Users/jdenney/workspace/github/forks/DCGAN-tensorflow/ops.py", line 99, in linear
    tf.random_normal_initializer(stddev=stddev))
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/ops/variable_scope.py", line 1317, in get_variable
    constraint=constraint)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/ops/variable_scope.py", line 1079, in get_variable
    constraint=constraint)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/ops/variable_scope.py", line 425, in get_variable
    constraint=constraint)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/ops/variable_scope.py", line 394, in _true_getter
    use_resource=use_resource, constraint=constraint)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/ops/variable_scope.py", line 738, in _get_single_variable
    found_var.get_shape()))
ValueError: ('Trying to share variable discriminator/d_h4_lin/Matrix, but specified shape (8192, 1) and found shape (25088, 1).', "NOTE: Usually, this is due to an issue with the image dimensions.  Did you correctly set '--crop' or '--input_height' or '--output_height'?")
```

Potentially closes #178   